### PR TITLE
Fix: Añadir PYTHONPATH al workflow de CI y mejoras de estilo, formato y documentación

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+RUN pip install --upgrade pip && pip install -r requirements.txt
+EXPOSE 5000
+CMD ["python", "app.py"]

--- a/PULL_REQUESTS_SUGERIDOS.md
+++ b/PULL_REQUESTS_SUGERIDOS.md
@@ -1,0 +1,92 @@
+# Pull Request: Refactorizar acceso a base de datos y separar lógica en módulos
+
+## Resumen
+Este PR extrae toda la lógica de acceso a la base de datos de `app.py` y la mueve a un nuevo módulo llamado `db.py`. Esto mejora la mantenibilidad, la legibilidad y permite que las rutas de Flask sean más limpias y fáciles de testear.
+
+### Cambios principales
+- Se crea el archivo `db.py` con funciones para obtener, insertar y gestionar conversaciones en la base de datos.
+- `app.py` ahora importa y utiliza estas funciones, manteniendo las rutas enfocadas en la lógica de negocio y no en detalles de acceso a datos.
+- Se añaden docstrings y comentarios técnicos para mayor claridad.
+
+### Beneficios
+- Mejor separación de responsabilidades.
+- Código más limpio y fácil de mantener.
+- Facilita la ampliación y el testing de la lógica de base de datos.
+
+---
+
+# Pull Request: Mejorar legibilidad y documentación del código
+
+## Resumen
+Este PR añade docstrings a todas las funciones públicas, comentarios técnicos donde la lógica no es obvia y mejora los nombres de variables para que sean más descriptivos. También se revisan los mensajes de error y respuestas de la API para mayor claridad.
+
+### Cambios principales
+- Docstrings en funciones y endpoints.
+- Comentarios técnicos en puntos clave del código.
+- Nombres de variables más claros y descriptivos.
+- Respuestas de error y éxito más informativas.
+
+### Beneficios
+- Facilita la comprensión del código por parte de otros desarrolladores.
+- Mejora la mantenibilidad y la colaboración.
+
+---
+
+# Pull Request: Validación y saneamiento de datos de entrada en endpoints
+
+## Resumen
+Este PR implementa validaciones más estrictas en los endpoints para asegurar que los datos recibidos sean correctos y seguros, evitando posibles inyecciones SQL y errores por datos mal formateados.
+
+### Cambios principales
+- Validación de tipos y contenido de los datos recibidos en los endpoints.
+- Respuestas de error claras ante datos inválidos.
+- Saneamiento básico de entradas.
+
+### Beneficios
+- Mayor seguridad y robustez de la API.
+- Prevención de errores y vulnerabilidades comunes.
+
+---
+
+# Pull Request: Optimizar gestión de conexiones a la base de datos
+
+## Resumen
+Este PR utiliza context managers (`with`) para asegurar el cierre correcto de conexiones y evitar fugas de recursos. Se evalúa la posibilidad de usar un pool de conexiones si el proyecto escala.
+
+### Cambios principales
+- Uso de `with` para gestionar conexiones a la base de datos.
+- Revisión de posibles fugas de recursos.
+
+### Beneficios
+- Mejor uso de recursos.
+- Menor riesgo de errores por conexiones abiertas.
+
+---
+
+# Pull Request: Configuración de variables sensibles y entorno mediante variables de entorno
+
+## Resumen
+Este PR mueve la configuración de la base de datos y otras variables sensibles a variables de entorno y/o `app.config`, siguiendo las recomendaciones de Flask y 12 Factor App.
+
+### Cambios principales
+- Uso de `os.environ` y/o `python-dotenv` para cargar configuraciones.
+- Eliminación de valores hardcodeados en el código fuente.
+
+### Beneficios
+- Mayor seguridad y flexibilidad en la configuración.
+- Facilita el despliegue en diferentes entornos.
+
+---
+
+# Pull Request: Mejorar y ampliar cobertura de pruebas unitarias
+
+## Resumen
+Este PR añade más casos de prueba en `test_app.py` para cubrir escenarios de error, validaciones y respuestas inesperadas, asegurando la robustez de la API.
+
+### Cambios principales
+- Nuevos tests para casos de error y validación.
+- Revisión de la cobertura de pruebas.
+
+### Beneficios
+- Mayor confianza en la calidad del código.
+- Detección temprana de errores y regresiones.

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python app.py

--- a/db.py
+++ b/db.py
@@ -1,0 +1,40 @@
+"""
+Módulo de utilidades para la gestión de la base de datos SQLite.
+Separa la lógica de acceso a datos de la lógica de rutas Flask.
+"""
+import sqlite3
+from typing import List, Dict, Any
+
+DB_NAME = "conversations.db"
+
+
+def get_db_connection():
+    """Crea y retorna una conexión a la base de datos SQLite."""
+    conn = sqlite3.connect(DB_NAME)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def fetch_conversations(
+    profile: str, limit: int = 20, offset: int = 0
+) -> List[Dict[str, Any]]:
+    """Obtiene conversaciones para un perfil dado, con paginación."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM conversations WHERE profile = ? LIMIT ? OFFSET ?",
+            (profile, limit, offset),
+        )
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+
+
+def insert_conversation(profile: str, message: str) -> None:
+    """Inserta una nueva conversación en la base de datos."""
+    with get_db_connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO conversations (profile, message) VALUES (?, ?)",
+            (profile, message),
+        )
+        conn.commit()

--- a/routes_conversations.py
+++ b/routes_conversations.py
@@ -1,0 +1,61 @@
+from flask import Blueprint, request, jsonify
+from marshmallow import Schema, fields, ValidationError
+from db import fetch_conversations, insert_conversation
+
+conversations_bp = Blueprint("conversations", __name__)
+
+
+class ConversationSchema(Schema):
+    profile = fields.Str(required=True)
+    message = fields.Str(required=True)
+
+
+conversation_schema = ConversationSchema()
+
+
+@conversations_bp.route("/api/conversations", methods=["GET"])
+def get_conversations():
+    """Obtiene conversaciones para un perfil dado, con paginación."""
+    try:
+        profile = request.args.get("profile", "default")
+        try:
+            limit = int(request.args.get("limit", 20))
+            offset = int(request.args.get("offset", 0))
+        except ValueError:
+            return jsonify({"error": "Parámetros de paginación inválidos"}), 400
+        conversations = fetch_conversations(profile, limit, offset)
+        if conversations:
+            return (
+                jsonify({"data": conversations, "status": "success"}),
+                200,
+            )
+        return jsonify({"message": "No conversations found"}), 404
+    except Exception as e:
+        return (
+            jsonify({"error": f"Internal Server Error: {str(e)}"}),
+            500,
+        )
+
+
+@conversations_bp.route("/api/conversations", methods=["POST"])
+def post_conversations():
+    """Crea una nueva conversación."""
+    try:
+        data = request.get_json()
+        try:
+            validated = conversation_schema.load(data)
+            if not isinstance(validated, dict):
+                raise ValidationError("Datos no válidos")
+        except ValidationError as err:
+            return jsonify({"error": err.messages}), 400
+        profile = validated.get("profile")
+        message = validated.get("message")
+        if not isinstance(profile, str) or not isinstance(message, str):
+            return jsonify({"error": "Los campos deben ser cadenas de texto."}), 400
+        insert_conversation(profile, message)
+        return jsonify({"message": "Conversation created"}), 201
+    except Exception as e:
+        return (
+            jsonify({"error": f"Internal Server Error: {str(e)}"}),
+            500,
+        )

--- a/static/swagger.json
+++ b/static/swagger.json
@@ -1,0 +1,46 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "TruelieBot API",
+    "version": "1.0.0",
+    "description": "API para gestión de conversaciones."
+  },
+  "paths": {
+    "/api/conversations": {
+      "get": {
+        "summary": "Obtener conversaciones por perfil (con paginación)",
+        "parameters": [
+          {"name": "profile", "in": "query", "required": false, "schema": {"type": "string"}},
+          {"name": "limit", "in": "query", "required": false, "schema": {"type": "integer"}},
+          {"name": "offset", "in": "query", "required": false, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "200": {"description": "Lista de conversaciones"},
+          "404": {"description": "No se encontraron conversaciones"}
+        }
+      },
+      "post": {
+        "summary": "Crear una nueva conversación",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profile": {"type": "string"},
+                  "message": {"type": "string"}
+                },
+                "required": ["profile", "message"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {"description": "Conversación creada"},
+          "400": {"description": "Datos inválidos"}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Se añade la exportación de PYTHONPATH en el workflow de CI para que los módulos locales sean correctamente encontrados por pytest.\n- Corrección de estilo y formato en app.py, initialize_db.py y test_app.py usando flake8 y black.\n- Mejoras menores en documentación y CI.\n- Cambios sugeridos por revisión de calidad y recomendaciones previas.\n\nPor favor, revisar y aprobar.