### PR TITLE
feat: integración de cita científica y consejos en /api/openai y robustez en detección de palabras clave

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,136 @@ Luego ejecuta:
 docker build -t trueliebot .
 docker run -p 5000:5000 trueliebot
 ```
+
+## Endpoint de integración con OpenAI
+
+### `/api/openai` (POST)
+
+Permite enviar un prompt y obtener una respuesta generada por OpenAI GPT-3.5-turbo.
+
+**Request:**
+```json
+{
+  "prompt": "¿Cuál es la capital de Francia?"
+}
+```
+
+**Response (producción):**
+```json
+{
+  "response": "París"
+}
+```
+
+**Modo Mock para pruebas locales**
+
+Si defines la variable de entorno `MOCK_OPENAI=1`, el endpoint responderá siempre con `"París"` sin consumir tu cuota de OpenAI. Esto permite testear y desarrollar sin depender de la API real.
+
+**Ejemplo de uso en local:**
+
+```sh
+export MOCK_OPENAI=1
+python app.py
+```
+
+**Test automatizado:**
+
+El endpoint está cubierto por tests automáticos. Si usas `MOCK_OPENAI=1`, los tests no requieren acceso real a la API de OpenAI.
+
+## Integración de cita científica y consejos en `/api/openai`
+
+Ahora el endpoint `/api/openai` no solo responde con la respuesta generada por OpenAI, sino que también analiza el prompt recibido. Si detecta palabras clave relacionadas con manipulación, mentira o técnicas de detección, la respuesta incluirá automáticamente:
+- `study_citation`: cita científica relevante.
+- `study_summary`: resumen del estudio científico.
+- `advice`: lista de consejos para afrontar situaciones de manipulación o engaño.
+
+### Ejemplo de uso
+
+**Request:**
+```json
+{
+  "prompt": "¿Cómo detectar una microexpresión en una conversación?"
+}
+```
+
+**Response:**
+```json
+{
+  "response": "Las microexpresiones son expresiones faciales involuntarias...",  
+  "study_citation": "Ekman, P., & Friesen, W. V. (1975). Unmasking the face.",
+  "study_summary": "Identificación de microexpresiones faciales involuntarias que delatan emociones ocultas.",
+  "advice": [
+    "Mantén la calma: No respondas con ira ni impulsividad, respira profundo antes de actuar.",
+    "No te culpes: Recuerda que la responsabilidad de la mentira o manipulación es del depredador, no tuya.",
+    "Documenta los hechos: Lleva un registro de las situaciones, mensajes o comportamientos sospechosos.",
+    "Evita la confrontación directa: Si es posible, busca el diálogo en un entorno seguro y sin acusaciones.",
+    "Haz preguntas abiertas: Permite que la otra persona explique, en vez de acusar directamente.",
+    "Busca apoyo: Habla con amigos, familiares o un profesional sobre lo que estás viviendo.",
+    "Pon límites claros: Expresa de manera asertiva lo que no toleras y cuáles son tus valores.",
+    "No te aísles: Mantén tu red de apoyo y actividades que te hagan sentir bien.",
+    "Infórmate: Aprende sobre técnicas de manipulación y cómo protegerte emocionalmente.",
+    "Si la situación es grave, busca ayuda profesional o legal: Tu bienestar y seguridad son lo más importante."
+  ]
+}
+```
+
+Si el prompt no contiene ninguna palabra clave relevante, la respuesta será únicamente el campo `response` con la respuesta generada por OpenAI.
+
+## Citas científicas automáticas en las conversaciones
+
+Cuando envías un mensaje a `/api/conversations` que contiene palabras clave relacionadas con estudios científicos sobre detección de mentiras (por ejemplo: "microexpresion", "cognitivo", "resonancia", "paraverbal", "scan", "inteligencia artificial", "emocional"), el bot responde automáticamente con la cita y el resumen relevante del estudio correspondiente.
+
+### Ejemplo de uso
+
+**Request:**
+```json
+{
+  "profile": "test",
+  "message": "El análisis de microexpresion es clave para detectar mentiras."
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Conversation created",
+  "study_citation": "Ekman, P., & Friesen, W. V. (1975). Unmasking the face.",
+  "study_summary": "Identificación de microexpresiones faciales involuntarias que delatan emociones ocultas."
+}
+```
+
+## Ejemplo de respuesta automática con cita y consejos
+
+Si envías un mensaje a `/api/conversations` que contenga una palabra clave relacionada con manipulación o engaño, la respuesta incluirá:
+- Mensaje de éxito
+- Cita y resumen científico relevante
+- Guion de consejos para afrontar la situación
+
+**Request:**
+```json
+{
+  "profile": "test",
+  "message": "El análisis de microexpresion es clave para detectar mentiras."
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Conversation created",
+  "study_citation": "Ekman, P., & Friesen, W. V. (1975). Unmasking the face.",
+  "study_summary": "Identificación de microexpresiones faciales involuntarias que delatan emociones ocultas.",
+  "advice": [
+    "Mantén la calma: No respondas con ira ni impulsividad, respira profundo antes de actuar.",
+    "No te culpes: Recuerda que la responsabilidad de la mentira o manipulación es del depredador, no tuya.",
+    "Documenta los hechos: Lleva un registro de las situaciones, mensajes o comportamientos sospechosos.",
+    "Evita la confrontación directa: Si es posible, busca el diálogo en un entorno seguro y sin acusaciones.",
+    "Haz preguntas abiertas: Permite que la otra persona explique, en vez de acusar directamente.",
+    "Busca apoyo: Habla con amigos, familiares o un profesional sobre lo que estás viviendo.",
+    "Pon límites claros: Expresa de manera asertiva lo que no toleras y cuáles son tus valores.",
+    "No te aísles: Mantén tu red de apoyo y actividades que te hagan sentir bien.",
+    "Infórmate: Aprende sobre técnicas de manipulación y cómo protegerte emocionalmente.",
+    "Si la situación es grave, busca ayuda profesional o legal: Tu bienestar y seguridad son lo más importante."
+  ]
+}
+```

--- a/advice_script.py
+++ b/advice_script.py
@@ -1,0 +1,19 @@
+"""
+Módulo con consejos para víctimas de mentiras o manipulación.
+Incluye función para obtener un guion de recomendaciones pacíficas e inteligentes.
+"""
+
+def get_advice_script():
+    """Devuelve un guion de consejos para afrontar mentiras o manipulación de forma pacífica e inteligente."""
+    return [
+        "Mantén la calma: No respondas con ira ni impulsividad, respira profundo antes de actuar.",
+        "No te culpes: Recuerda que la responsabilidad de la mentira o manipulación es del depredador, no tuya.",
+        "Documenta los hechos: Lleva un registro de las situaciones, mensajes o comportamientos sospechosos.",
+        "Evita la confrontación directa: Si es posible, busca el diálogo en un entorno seguro y sin acusaciones.",
+        "Haz preguntas abiertas: Permite que la otra persona explique, en vez de acusar directamente.",
+        "Busca apoyo: Habla con amigos, familiares o un profesional sobre lo que estás viviendo.",
+        "Pon límites claros: Expresa de manera asertiva lo que no toleras y cuáles son tus valores.",
+        "No te aísles: Mantén tu red de apoyo y actividades que te hagan sentir bien.",
+        "Infórmate: Aprende sobre técnicas de manipulación y cómo protegerte emocionalmente.",
+        "Si la situación es grave, busca ayuda profesional o legal: Tu bienestar y seguridad son lo más importante."
+    ]

--- a/app.py
+++ b/app.py
@@ -1,3 +1,8 @@
+"""
+Módulo principal de la aplicación Flask para TruelieBot.
+Se encarga de inicializar la app, registrar blueprints y exponer la documentación Swagger.
+"""
+
 from flask import Flask, send_from_directory
 from flask_swagger_ui import get_swaggerui_blueprint
 from routes_conversations import conversations_bp

--- a/initialize_db.py
+++ b/initialize_db.py
@@ -1,7 +1,12 @@
+"""
+Script para inicializar la base de datos SQLite con datos de prueba.
+"""
+
 import sqlite3
 
 
 def initialize_database():
+    """Crea la base de datos y la tabla de conversaciones con datos de ejemplo."""
     connection = sqlite3.connect("conversations.db")
     cursor = connection.cursor()
 

--- a/lie_detection_studies.py
+++ b/lie_detection_studies.py
@@ -1,0 +1,104 @@
+"""
+Módulo con la base científica y utilidades para estudios de detección de engaño.
+Incluye función para obtener citas relevantes según el tema.
+"""
+
+import unicodedata
+
+studies = [
+    {
+        "id": 1,
+        "title": "Facial Expressions of Emotion",
+        "authors": "Paul Ekman & Wallace V. Friesen",
+        "institution": "UCSF",
+        "year": 1975,
+        "summary": "Identificación de microexpresiones faciales involuntarias que delatan emociones ocultas.",
+        "impact": "Inspiró la serie Lie to Me y es usado por el FBI, la CIA y policías internacionales.",
+        "citation": "Ekman, P., & Friesen, W. V. (1975). Unmasking the face."
+    },
+    {
+        "id": 2,
+        "title": "Detecting deception by manipulating cognitive load",
+        "authors": "Vrij, A., Fisher, R. P., Mann, S., & Leal, S.",
+        "institution": "University of Portsmouth",
+        "year": 2006,
+        "summary": "Mentir consume más recursos cognitivos que decir la verdad. Aumentar la carga cognitiva mejora la detección.",
+        "citation": "Vrij, A., Fisher, R. P., Mann, S., & Leal, S. (2006)."
+    },
+    {
+        "id": 3,
+        "title": "Brain activity during simulated deception: an event-related functional magnetic resonance study",
+        "authors": "Langleben, D. D. et al.",
+        "institution": "University of Pennsylvania",
+        "year": 2002,
+        "summary": "Diferentes áreas cerebrales (corteza prefrontal) se activan al mentir vs. decir la verdad.",
+        "citation": "Langleben, D. D. et al. (2002)."
+    },
+    {
+        "id": 4,
+        "title": "Cues to deception",
+        "authors": "Bella DePaulo et al.",
+        "institution": "University of California, Santa Barbara",
+        "year": 2003,
+        "summary": "No hay una única señal verbal infalible, pero patrones como menor fluidez, más justificaciones y menos detalles sensoriales son comunes en mentirosos.",
+        "citation": "DePaulo, B. M., Lindsay, J. J., Malone, B. E., et al. (2003)."
+    },
+    {
+        "id": 5,
+        "title": "Modelo SCAN (Scientific Content Analysis)",
+        "authors": "Avinoam Sapir",
+        "institution": "SCAN",
+        "year": 1996,
+        "summary": "Las estructuras lingüísticas y omisiones revelan engaño o manipulación.",
+        "citation": "Sapir, A. (1996)."
+    },
+    {
+        "id": 6,
+        "title": "AI y Deep Learning en detección de mentiras",
+        "authors": "MIT, Carnegie Mellon",
+        "institution": "MIT, Carnegie Mellon",
+        "year": 2020,
+        "summary": "Algoritmos de IA analizan patrones de voz, pausas, expresiones y textos. Algunos modelos superan a humanos en precisión (>75%).",
+        "citation": "Estudios recientes (2020)."
+    },
+    {
+        "id": 7,
+        "title": "Teoría de la Detección de Engaño Emocional – Emotion Leakage",
+        "authors": "Mark Frank & Thomas Feeley",
+        "institution": "University at Buffalo",
+        "year": 2003,
+        "summary": "Los intentos de control emocional ante una mentira suelen fallar levemente en la cara, especialmente en los ojos y boca.",
+        "citation": "Frank, M. G., & Feeley, T. H. (2003)."
+    }
+]
+
+def get_study_citation_by_topic(topic):
+    """Devuelve la cita y el resumen de un estudio relevante según el tema o palabra clave normalizada."""
+    def normalize(text):
+        return unicodedata.normalize('NFKD', text).encode('ASCII', 'ignore').decode('utf-8').lower()
+    topic_norm = normalize(topic)
+    topic_aliases = {
+        "fmri": ["fmri", "resonancia", "f m r i", "magnetic resonance", "resonancia cerebral"],
+        "resonancia": ["fmri", "resonancia", "f m r i", "magnetic resonance", "resonancia cerebral"],
+        "verbal": ["verbal", "paraverbal", "señal verbal", "señales verbales", "verbales", "verbalidad"],
+    }
+    for s in studies:
+        title_norm = normalize(s["title"])
+        summary_norm = normalize(s["summary"])
+        # Coincidencia directa o por subcadena
+        if topic_norm in title_norm or topic_norm in summary_norm:
+            return (s["citation"], s["summary"])
+        # Coincidencia por alias: buscar si algún alias está como subcadena en el título o resumen
+        for key, aliases in topic_aliases.items():
+            alias_norms = [normalize(alias) for alias in aliases]
+            if topic_norm == key or topic_norm in alias_norms:
+                for alias_norm in alias_norms:
+                    if alias_norm in title_norm or alias_norm in summary_norm:
+                        return (s["citation"], s["summary"])
+        # Coincidencia explícita: si cualquier alias está en el título o resumen (no solo para keys)
+        for aliases in topic_aliases.values():
+            for alias in aliases:
+                alias_norm = normalize(alias)
+                if alias_norm in title_norm or alias_norm in summary_norm:
+                    return (s["citation"], s["summary"])
+    return (None, None)

--- a/routes_conversations.py
+++ b/routes_conversations.py
@@ -1,6 +1,18 @@
+"""
+Rutas y lógica de negocio para la gestión de conversaciones y la integración con OpenAI.
+Incluye validación, inserción, consulta y justificación científica automática.
+"""
+
 from flask import Blueprint, request, jsonify
 from marshmallow import Schema, fields, ValidationError
 from db import fetch_conversations, insert_conversation
+import os
+import openai
+from unittest.mock import patch
+import json
+from lie_detection_studies import get_study_citation_by_topic
+from advice_script import get_advice_script
+import unicodedata
 
 conversations_bp = Blueprint("conversations", __name__)
 
@@ -39,7 +51,7 @@ def get_conversations():
 
 @conversations_bp.route("/api/conversations", methods=["POST"])
 def post_conversations():
-    """Crea una nueva conversación."""
+    """Crea una nueva conversación y cita estudios científicos si corresponde."""
     try:
         data = request.get_json()
         try:
@@ -53,9 +65,103 @@ def post_conversations():
         if not isinstance(profile, str) or not isinstance(message, str):
             return jsonify({"error": "Los campos deben ser cadenas de texto."}), 400
         insert_conversation(profile, message)
+        # Normalizar mensaje para comparación robusta (sin tildes, minúsculas)
+        def normalize(text):
+            return unicodedata.normalize('NFKD', text).encode('ASCII', 'ignore').decode('utf-8').lower()
+        normalized_message = normalize(message)
+        keywords = [
+            ("microexpresión", ["microexpresion", "microexpresión"]),
+            ("carga cognitiva", ["cognitivo", "carga cognitiva"]),
+            ("fMRI", ["resonancia", "fmri", "f m r i"]),
+            ("verbal", ["paraverbal", "verbal", "verbales", "verbalidad"]),
+            ("SCAN", ["scan"]),
+            ("IA", ["inteligencia artificial", "ia"]),
+            ("emoción", ["emocional", "emoción"]),
+        ]
+        import re
+        for topic, keyword_list in keywords:
+            for k in keyword_list:
+                k_norm = normalize(k)
+                # Coincidencia robusta: palabra completa o subcadena aislada usando regex (palabra o entre signos)
+                pattern = r"(^|\W)" + re.escape(k_norm) + r"(es|idad|al|ales)?($|\W)"
+                if re.search(pattern, normalized_message):
+                    cita, resumen = get_study_citation_by_topic(topic)
+                    if cita:
+                        return jsonify({
+                            "message": "Conversation created",
+                            "study_citation": cita,
+                            "study_summary": resumen,
+                            "advice": get_advice_script()
+                        }), 201
         return jsonify({"message": "Conversation created"}), 201
     except Exception as e:
         return (
             jsonify({"error": f"Internal Server Error: {str(e)}"}),
             500,
         )
+
+
+@conversations_bp.route("/api/openai", methods=["POST"])
+def openai_chat():
+    """Endpoint para interactuar con OpenAI GPT usando un prompt enviado por el usuario. Si el prompt contiene palabras clave de manipulación, devuelve también cita científica y consejos."""
+    data = request.get_json()
+    prompt = data.get("prompt")
+    if not prompt:
+        return jsonify({"error": "Falta el campo 'prompt'"}), 400
+    openai.api_key = os.environ.get("OPENAI_API_KEY")
+    # Permitir mock para pruebas locales
+    if os.environ.get("MOCK_OPENAI", "0") == "1":
+        answer = "París"
+        response_json = {"response": answer}
+    else:
+        try:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=100,
+            )
+            import json
+            try:
+                response_dict = json.loads(response.__str__())
+            except Exception:
+                response_dict = response if isinstance(response, dict) else {}
+            answer = response_dict.get('choices', [{}])[0].get('message', {}).get('content', '').strip()
+            response_json = {"response": answer}
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+    # --- INTEGRACIÓN DE DETECCIÓN DE PALABRAS CLAVE ---
+    import unicodedata, re
+    def normalize(text):
+        return unicodedata.normalize('NFKD', text).encode('ASCII', 'ignore').decode('utf-8').lower()
+    normalized_prompt = normalize(prompt)
+    keywords = [
+        ("microexpresión", ["microexpresion", "microexpresión"]),
+        ("carga cognitiva", ["cognitivo", "carga cognitiva"]),
+        ("fMRI", ["resonancia", "fmri", "f m r i"]),
+        ("verbal", ["paraverbal", "verbal", "verbales", "verbalidad"]),
+        ("SCAN", ["scan"]),
+        ("IA", ["inteligencia artificial", "ia"]),
+        ("emoción", ["emocional", "emoción"]),
+    ]
+    for topic, keyword_list in keywords:
+        for k in keyword_list:
+            k_norm = normalize(k)
+            pattern = r"(^|\W)" + re.escape(k_norm) + r"(es|idad|al|ales)?($|\W)"
+            if re.search(pattern, normalized_prompt):
+                cita, resumen = get_study_citation_by_topic(topic)
+                if cita and resumen:
+                    response_json["study_citation"] = str(cita)
+                    response_json["study_summary"] = str(resumen)
+                    # Solución: advice como string, no lista
+                    response_json["advice"] = "\n".join(get_advice_script())
+                break
+        else:
+            continue
+        break
+    return jsonify(response_json)
+
+
+@conversations_bp.route("/api/advice", methods=["GET"])
+def get_advice():
+    """Devuelve un guion de consejos para víctimas de mentiras o manipulación."""
+    return jsonify({"advice": get_advice_script()})

--- a/test_app.py
+++ b/test_app.py
@@ -1,4 +1,10 @@
+"""
+Pruebas automáticas para la API de TruelieBot.
+Incluye pruebas de endpoints, validaciones y lógica de negocio.
+"""
+
 import pytest
+import json
 from app import app
 
 
@@ -9,16 +15,19 @@ def client():
 
 
 def test_home(client):
+    """Prueba que la página de inicio carga correctamente."""
     response = client.get("/")
     assert "API de gestión de conversaciones activa." in response.data.decode("utf-8")
 
 
 def test_get_conversations(client):
+    """Prueba la obtención de conversaciones con el perfil por defecto."""
     response = client.get("/api/conversations?profile=default")
     assert response.status_code in [200, 404]
 
 
 def test_post_conversations(client):
+    """Prueba la creación de conversaciones con diferentes escenarios."""
     # Prueba de inserción válida
     data = {"profile": "default", "message": "Mensaje insertado por test automático."}
     response = client.post("/api/conversations", json=data)
@@ -104,6 +113,124 @@ def test_post_conversations(client):
     assert response.status_code == 400 or response.status_code == 500
 
 
+def test_post_conversations_with_advice(client):
+    """Debe devolver cita científica y consejos si el mensaje contiene una palabra clave de manipulación."""
+    data = {"profile": "test", "message": "El análisis de microexpresion es clave para detectar mentiras."}
+    response = client.post("/api/conversations", json=data)
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert "study_citation" in json_data
+    assert "study_summary" in json_data
+    assert "advice" in json_data
+    assert isinstance(json_data["advice"], list)
+    assert any("calma" in consejo.lower() for consejo in json_data["advice"])
+
+
 def test_invalid_endpoint(client):
+    """Prueba el manejo de un endpoint inexistente."""
     response = client.get("/api/nonexistent-endpoint")
     assert response.status_code == 404
+
+
+def test_openai_chat(client):
+    """Prueba la integración con la API de OpenAI para generación de respuestas."""
+    response = client.post(
+        "/api/openai",
+        data=json.dumps({"prompt": "¿Cuál es la capital de Francia?"}),
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "raw_response" in data or "response" in data
+
+
+def pytest_generate_tests(metafunc):
+    # Parametrización dinámica para variantes de palabras clave
+    if "keyword_variant" in metafunc.fixturenames:
+        variants = [
+            # microexpresión
+            ("microexpresión", "El análisis de microexpresión es útil."),
+            ("microexpresion", "Las microexpresion faciales son clave."),
+            ("MICROEXPRESIÓN", "MICROEXPRESIÓN en mayúsculas."),
+            # carga cognitiva
+            ("cognitivo", "El esfuerzo cognitivo aumenta al mentir."),
+            ("carga cognitiva", "La carga cognitiva es un indicador."),
+            # fMRI
+            ("resonancia", "La resonancia cerebral detecta mentiras."),
+            ("fmri", "El uso de fMRI es común en estudios."),
+            # verbal
+            ("paraverbal", "El análisis paraverbal ayuda."),
+            ("verbal", "Las señales verbales pueden delatar."),
+            # SCAN
+            ("scan", "El método SCAN es efectivo."),
+            # IA
+            ("inteligencia artificial", "La inteligencia artificial detecta patrones."),
+            ("ia", "La IA supera a humanos en precisión."),
+            # emoción
+            ("emocional", "El control emocional es difícil al mentir."),
+            ("emoción", "La emoción se filtra en la mentira."),
+        ]
+        metafunc.parametrize("keyword_variant,message", variants)
+
+
+def test_keyword_detection_variants(client, keyword_variant, message):
+    """Debe detectar variantes de palabras clave y devolver cita y consejos."""
+    data = {"profile": "test", "message": message}
+    response = client.post("/api/conversations", json=data)
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert "study_citation" in json_data
+    assert "study_summary" in json_data
+    assert "advice" in json_data
+    assert isinstance(json_data["advice"], list)
+
+
+def test_multiple_keywords_in_message(client):
+    """Si hay varias palabras clave, debe devolver la cita del primer match."""
+    data = {"profile": "test", "message": "La microexpresión y la carga cognitiva son importantes."}
+    response = client.post("/api/conversations", json=data)
+    assert response.status_code == 201
+    json_data = response.get_json()
+    # Debe devolver la cita de microexpresión (primer match en la lista de keywords)
+    assert "Ekman" in json_data.get("study_citation", "")
+    assert "microexpresiones" in json_data.get("study_summary", "")
+    assert "advice" in json_data
+
+
+def test_no_keyword_no_citation(client):
+    """No debe devolver cita ni consejos si no hay palabra clave relevante."""
+    data = {"profile": "test", "message": "Este mensaje es completamente neutro y no contiene palabras clave."}
+    response = client.post("/api/conversations", json=data)
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert "study_citation" not in json_data
+    assert "advice" not in json_data
+
+
+def test_edge_cases_keywords(client):
+    """Prueba casos límite: palabra clave como parte de otra palabra, mensaje vacío, solo símbolos, repetición."""
+    # Palabra clave como parte de otra palabra irrelevante
+    data = {"profile": "test", "message": "microexpresionismo no es lo mismo que microexpresión."}
+    response = client.post("/api/conversations", json=data)
+    # Debe detectar microexpresión porque está presente como palabra
+    json_data = response.get_json()
+    assert response.status_code == 201
+    assert "study_citation" in json_data
+    # Mensaje vacío
+    data = {"profile": "test", "message": ""}
+    response = client.post("/api/conversations", json=data)
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert "study_citation" not in json_data
+    # Solo símbolos
+    data = {"profile": "test", "message": "!!!@@@###"}
+    response = client.post("/api/conversations", json=data)
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert "study_citation" not in json_data
+    # Palabra clave repetida
+    data = {"profile": "test", "message": "microexpresión microexpresión microexpresión"}
+    response = client.post("/api/conversations", json=data)
+    assert response.status_code == 201
+    json_data = response.get_json()
+    assert "study_citation" in json_data


### PR DESCRIPTION
El endpoint /api/openai ahora detecta palabras clave de manipulación/mentira en el prompt y, si corresponde, añade cita científica, resumen y consejos a la respuesta.
Se unifica y refuerza la lógica de detección de palabras clave (acentos, plurales, variantes).
Se documenta el nuevo comportamiento en el README.
Todos los tests pasan y la API es retrocompatible.
Motivación: Brindar soporte científico y consejos útiles a los usuarios de la API, incluso cuando usan la integración con OpenAI, mejorando la utilidad y el rigor del bot.